### PR TITLE
fix: update multer to a non-vulnerable version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "resolutions": {
     "sharp": "0.33.0",
-    "gatsby-sharp": "1.12.0"
+    "gatsby-sharp": "1.12.0",
+    "multer": "^2.0.2"
   },
   "scripts": {
     "start": "gatsby build && gatsby serve",


### PR DESCRIPTION
## Description
Update Multer, a dependency of Gatsby, to a non-vulnerable version.

## Motivation and Context
This PR addresses the following security alert:
https://github.com/AdobeDocs/ffs-s3d-api/security/dependabot/45

<img width="1728" height="1040" alt="Screenshot 2025-08-01 at 10 46 09 AM" src="https://github.com/user-attachments/assets/8da09f26-4710-4a88-aee8-bc533263af0f" />


We can't upgrade Gatsby (Multer due to aio-theme limitations), so we are overriding the nested dependency instead.

## How Has This Been Tested?
Need to merge this first, which would trigger the dependabot check, and see if this removes the security alert.

